### PR TITLE
Circular dependency in Makefile: touch it

### DIFF
--- a/make/config.mk
+++ b/make/config.mk
@@ -25,6 +25,7 @@ GHCI		= ghci
 GHC_VERSION	= $(shell $(GHC) --version | sed -e "s/.* //g" -e "s/\..*//")
 GHC_VERSION_FLAGS = -rtsopts
 
+GHC_DEPS_HI_TO_O = sed 's/\.hi$$/.o/'
 
 # Linear solver time
 DDC_FLOW_USE_LINEAR_SOLVER = 1

--- a/make/rules.mk
+++ b/make/rules.mk
@@ -15,8 +15,20 @@ packages/ddc-code/sea/%.o : packages/ddc-code/sea/%.c
 	@alex -g $<
 
 
+# Add a dependency from .hi to .o because ghc produces dependencies like
+# > A.o : B.hi
+# when module A depends on B.
+#
+# However, this creates a circular dependency because GHC might
+# output the .hi before the .o!
+# This causes make to rebuild the .hi since the .o is newer.
+#
+# So in the rule below we touch the .hi file after building the .o.
+# This way the .o is older and will not cause a rebuild.
 %.hi : %.o
 	@true
+%.o : %.hs
+	touch $(patsubst %.o,%.hi,$@)
 
 
 %.dep : %.c

--- a/make/rules.mk
+++ b/make/rules.mk
@@ -15,22 +15,6 @@ packages/ddc-code/sea/%.o : packages/ddc-code/sea/%.c
 	@alex -g $<
 
 
-# Add a dependency from .hi to .o because ghc produces dependencies like
-# > A.o : B.hi
-# when module A depends on B.
-#
-# However, this creates a circular dependency because GHC might
-# output the .hi before the .o!
-# This causes make to rebuild the .hi since the .o is newer.
-#
-# So in the rule below we touch the .hi file after building the .o.
-# This way the .o is older and will not cause a rebuild.
-%.hi : %.o
-	@true
-%.o : %.hs
-	touch $(patsubst %.o,%.hi,$@)
-
-
 %.dep : %.c
 	@echo "* Dependencies for $<"
 	@gcc $(GCC_FLAGS) -MM $< -MT $(patsubst %.dep,%.o,$@) -o $@

--- a/make/targets/ddc-check.mk
+++ b/make/targets/ddc-check.mk
@@ -26,7 +26,7 @@ make/deps/Makefile-ddc-check.deps : $(ddc-check_src_hs_all)
 		-M $^ -dep-makefile make/deps/Makefile-ddc-check.deps \
                 -dep-suffix "" $(GHC_INCDIRS)
 	@rm -f make/deps/Makefile-ddc-check.deps.bak
-	@cp make/deps/Makefile-ddc-check.deps make/deps/Makefile-ddc-check.deps.inc
+	@$(GHC_DEPS_HI_TO_O) make/deps/Makefile-ddc-check.deps > make/deps/Makefile-ddc-check.deps.inc
 
 
 # Build object files.

--- a/make/targets/ddc-main.mk
+++ b/make/targets/ddc-main.mk
@@ -28,7 +28,7 @@ make/deps/Makefile-ddc-main.deps : $(ddc-main_src_hs_all)
 		-M $^ -dep-makefile make/deps/Makefile-ddc-main.deps \
                 -dep-suffix "" $(GHC_INCDIRS)
 	@rm -f make/deps/Makefile-ddc-main.deps.bak
-	@cp make/deps/Makefile-ddc-main.deps make/deps/Makefile-ddc-main.deps.inc
+	@$(GHC_DEPS_HI_TO_O) make/deps/Makefile-ddc-main.deps > make/deps/Makefile-ddc-main.deps.inc
 
 
 # Build object files.

--- a/make/targets/ddci-core.mk
+++ b/make/targets/ddci-core.mk
@@ -33,7 +33,7 @@ make/deps/Makefile-ddci-core.deps : $(ddci-core_src_hs_all)
 		-M $^ -dep-makefile make/deps/Makefile-ddci-core.deps \
                 -dep-suffix "" $(GHC_INCDIRS)
 	@rm -f make/deps/Makefile-ddci-core.deps.bak
-	@cp make/deps/Makefile-ddci-core.deps make/deps/Makefile-ddci-core.deps.inc
+	@$(GHC_DEPS_HI_TO_O) make/deps/Makefile-ddci-core.deps > make/deps/Makefile-ddci-core.deps.inc
 
 
 # Build object files.

--- a/make/targets/ddci-tetra.mk
+++ b/make/targets/ddci-tetra.mk
@@ -32,7 +32,7 @@ make/deps/Makefile-ddci-tetra.deps : $(ddci-tetra_src_hs_all)
 		-M $^ -dep-makefile make/deps/Makefile-ddci-tetra.deps \
                 -dep-suffix "" $(GHC_INCDIRS)
 	@rm -f make/deps/Makefile-ddci-tetra.deps.bak
-	@cp make/deps/Makefile-ddci-tetra.deps make/deps/Makefile-ddci-tetra.deps.inc
+	@$(GHC_DEPS_HI_TO_O) make/deps/Makefile-ddci-tetra.deps > make/deps/Makefile-ddci-tetra.deps.inc
 
 
 # Build object files.

--- a/make/targets/war.mk
+++ b/make/targets/war.mk
@@ -9,7 +9,7 @@ make/deps/Makefile-war.deps : $(war_src_hs_all)
 	@$(GHC) -M $^ -dep-makefile make/deps/Makefile-war.deps \
                 -dep-suffix "" $(GHC_INCDIRS)
 	@rm -f make/deps/Makefile-war.deps.bak
-	@cp make/deps/Makefile-war.deps make/deps/Makefile-war.deps.inc
+	@$(GHC_DEPS_HI_TO_O) make/deps/Makefile-war.deps > make/deps/Makefile-war.deps.inc
 
 
 # -- Link war -------------------------------------------------------------------------------------


### PR DESCRIPTION
Add a dependency from .hi to .o because ghc produces dependencies like
> A.o : B.hi

when module A depends on B.

However, this creates a circular dependency because GHC might
output the .hi before the .o!
This causes make to rebuild the .hi since the .o is newer.

So in the rule below we touch the .hi file after building the .o.
This way the .o is older and will not cause a rebuild.


@benl23x5 
I know you said I could merge things but I'd rather you verify this makefile stuff