### PR TITLE
This one weird trick to speed up your makefiles

### DIFF
--- a/make/rules.mk
+++ b/make/rules.mk
@@ -15,8 +15,10 @@ packages/ddc-code/sea/%.o : packages/ddc-code/sea/%.c
 	@alex -g $<
 
 
+# This ':' is equivalent to 'true', but much faster.
+# Strange.
 %.hi : %.o
-	@true
+	@:
 
 
 %.dep : %.c


### PR DESCRIPTION
The colon builtin shell function `:` is equivalent to `true`, but much
faster.
Significantly faster on my machine: 20x faster, which makes it seem like
a single call to `true` is 0.15s.
You might be using a better shell than me, which would explain the speed difference, but `:` is posix so should work anywhere.