### PR TITLE
Travis setup and C99-violation fixes

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,41 @@
+language: generic
+
+sudo: true
+
+# using ghc and cabal-install from https://launchpad.net/~hvr/+archive/ubuntu/ghc
+# llvm from
+#   https://launchpad.net/~h-rayflood/+archive/ubuntu/llvm
+#   https://launchpad.net/~h-rayflood/+archive/ubuntu/gcc-upper
+#   https://launchpad.net/~h-rayflood/+archive/ubuntu/llvm-upper
+before_install:
+    - sudo add-apt-repository -y ppa:h-rayflood/llvm
+    - sudo add-apt-repository -y ppa:h-rayflood/gcc-upper
+    - sudo add-apt-repository -y ppa:h-rayflood/llvm-upper
+    - sudo add-apt-repository -y ppa:hvr/ghc
+    - sudo apt-get update
+    - sudo apt-get install --force-yes llvm-3.5-dev llvm-3.5-runtime llvm-3.5
+    - sudo apt-get install --force-yes ghc-8.0.1 cabal-install-1.24
+    # put llvm-3.5 at the front of the path, ahead of any llvm-3.4
+    - export PATH=/usr/lib/llvm-3.5/bin:$PATH
+    # put ghc and cabal on the path
+    - export PATH=/opt/ghc/8.0.1/bin:/opt/cabal/1.24/bin:$PATH
+    - cabal update
+
+# here we manually install all the needed deps
+# by default travis would run `cabal install --only-dependencies --enable-tests`
+# cabal install was unhappy when all deps were specified, so we install them
+# one-by-one in the right order
+install:
+    - cabal install happy
+    - cabal install pretty-show
+    - cabal install alex
+    - cabal install c2hs
+    - cabal install limp-cbc
+    - cabal install buildbox
+    - cabal install ddc-tools
+
+script:
+    - make clean
+    - make
+    - make war
+

--- a/packages/ddc-code/salt/runtime64/debug/Trace.dcs
+++ b/packages/ddc-code/salt/runtime64/debug/Trace.dcs
@@ -392,9 +392,9 @@ traceSmall [r: Region] (print: Bool#) (obj: Ptr# r Obj): Ptr# r Obj
 -- @llvm.gcroot is null.
 --
 -- struct FrameMap {
---   int32_t NumRoots;    //< Number of roots in stack frame.
---   int32_t NumMeta;     //< Number of metadata entries.  May be < NumRoots.
---   const void *Meta[0]; //< Metadata for each root.
+--   uint32_t NumRoots;    //< Number of roots in stack frame.
+--   uint32_t NumMeta;     //< Number of metadata entries.  May be < NumRoots.
+--   const void *Meta[]; //< Metadata for each root.
 -- };
 -- 
 --  @brief A link in the dynamic shadow stack.  One of these is embedded in
@@ -402,7 +402,7 @@ traceSmall [r: Region] (print: Bool#) (obj: Ptr# r Obj): Ptr# r Obj
 -- struct StackEntry {
 --   StackEntry *Next;    //< Link to next stack entry (the caller's).
 --   const FrameMap *Map; //< Pointer to constant FrameMap.
---   void *Roots[0];      //< Stack roots (in-place array).
+--   void *Roots[];      //< Stack roots (in-place array).
 -- };
 
 -- @brief The head of the singly-linked list of StackEntries.  Functions push

--- a/packages/ddc-code/sea/primitive/Primitive.c
+++ b/packages/ddc-code/sea/primitive/Primitive.c
@@ -2,6 +2,7 @@
 // Primitive operations that sea code uses.
 // In future we'll just import these with the FFI.
 #include <stdio.h>
+#include <inttypes.h>
 #include "Runtime.h"
 
 
@@ -94,7 +95,7 @@ nat_t   ddcLlvmRootIsEnd (void* p)
 Obj*    primErrorDefault(string_t* source, uint32_t line)
 {
         fprintf ( stderr
-                , "\nDDC runtime error: inexhaustive case match.\n at: %s:%d\n"
+                , "\nDDC runtime error: inexhaustive case match.\n at: %s:%" PRId32 "\n"
                 , source, line);
         exit(1);
 
@@ -128,28 +129,28 @@ string_t* primShowNat (nat_t i)
 // Show a Word64.
 string_t* primShowWord64 (uint64_t w)
 {       string_t* str = malloc(11);
-        snprintf(str, 10, "%#08llx", w);
+        snprintf(str, 10, "%#08" PRIx64, w);
         return str;
 }
 
 // Show a Word32.
 string_t* primShowWord32 (uint32_t w)
 {       string_t* str = malloc(7);
-        snprintf(str, 6, "%#04x", w);
+        snprintf(str, 6, "%#04" PRIx32, w);
         return str;
 }
 
 // Show a Word16.
 string_t* primShowWord16 (uint16_t w)
 {       string_t* str = malloc(5);
-        snprintf(str, 4, "%#02x", w);
+        snprintf(str, 4, "%#02" PRIx16, w);
         return str;
 }
 
 // Show a Word8.
 string_t* primShowWord8 (uint8_t w)
 {       string_t* str = malloc(4);
-        snprintf(str, 3, "%#01x", w);
+        snprintf(str, 3, "%#01" PRIx8, w);
         return str;
 }
 

--- a/packages/ddc-code/sea/primitive/Primitive.c
+++ b/packages/ddc-code/sea/primitive/Primitive.c
@@ -15,7 +15,7 @@
 struct FrameMap {
   int32_t NumRoots;    //< Number of roots in stack frame.
   int32_t NumMeta;     //< Number of metadata entries.  May be < NumRoots.
-  const void *Meta[0]; //< Metadata for each root.
+  const void *Meta[]; //< Metadata for each root.
 };
 
 
@@ -24,7 +24,7 @@ struct FrameMap {
 struct StackEntry {
   struct StackEntry *Next;    //< Link to next stack entry (the caller's).
   const struct FrameMap *Map; //< Pointer to constant FrameMap.
-  void *Roots[0];             //< Stack roots (in-place array).
+  void *Roots[];             //< Stack roots (in-place array).
 };
 
 

--- a/packages/ddc-code/sea/primitive/Primitive.c
+++ b/packages/ddc-code/sea/primitive/Primitive.c
@@ -13,8 +13,8 @@
 /// Storage of metadata values is elided if the %metadata parameter to
 /// @llvm.gcroot is null.
 struct FrameMap {
-  int32_t NumRoots;    //< Number of roots in stack frame.
-  int32_t NumMeta;     //< Number of metadata entries.  May be < NumRoots.
+  uint32_t NumRoots;    //< Number of roots in stack frame.
+  uint32_t NumMeta;     //< Number of metadata entries.  May be < NumRoots.
   const void *Meta[]; //< Metadata for each root.
 };
 
@@ -45,14 +45,14 @@ struct StackEntry *llvm_gc_root_chain;
 /// @param Visitor A function to invoke for every GC root on the stack.
 void visitGCRoots(void (*Visitor)(void **Root, const void *Meta)) {
   for (struct StackEntry *R = llvm_gc_root_chain; R; R = R->Next) {
-    unsigned i = 0;
+    uint32_t i = 0;
 
     // For roots [0, NumMeta), the metadata pointer is in the FrameMap.
-    for (unsigned e = R->Map->NumMeta; i != e; ++i)
+    for (uint32_t e = R->Map->NumMeta; i != e; ++i)
       Visitor(&R->Roots[i], R->Map->Meta[i]);
 
     // For roots [NumMeta, NumRoots), the metadata pointer is null.
-    for (unsigned e = R->Map->NumRoots; i != e; ++i)
+    for (uint32_t e = R->Map->NumRoots; i != e; ++i)
       Visitor(&R->Roots[i], NULL);
   }
 }
@@ -60,16 +60,16 @@ void visitGCRoots(void (*Visitor)(void **Root, const void *Meta)) {
 
 void traceGCRoots (int _x) {
   for (struct StackEntry *R = llvm_gc_root_chain; R; R = R->Next) {
-    unsigned i = 0;
+    uint32_t i = 0;
 
     printf ("map %p\n", R->Map);
 
     // For roots [0, NumMeta), the metadata pointer is in the FrameMap.
-    for (unsigned e = R->Map->NumMeta; i != e; ++i)
+    for (uint32_t e = R->Map->NumMeta; i != e; ++i)
       printf ("root with meta %p\n", R->Roots[i]);
 
     // For roots [NumMeta, NumRoots), the metadata pointer is null.
-    for (unsigned e = R->Map->NumRoots; i != e; ++i)
+    for (uint32_t e = R->Map->NumRoots; i != e; ++i)
       printf ("root no   meta %p\n", R->Roots[i]);
   }
 } 


### PR DESCRIPTION
Adding a travis config with a linux target (ghc 8.0.1, cabal-install-1.24, llvm-3.5)

Travis also picked up a C99 violation, so I poked around Primitives.c and fixed a few more.

If you want to integrate Travis then I will need someone with 'member' access to DDCSF/ddc to perform some travis permission steps.
Travis integration would mean that every push to any branch is run through travis, which builds and tests under Linux (later on I can add OSX).
Travis integration would also mean every pull request is also tested, with the results posted to it, so you can see the testing results before you merge it.

To setup travis you need to:
Follow the first 2 steps here https://docs.travis-ci.com/user/getting-started/
Merge this commit

If this is accepted I can add a badge to your README showing the current travis status.

I'm currently only building for one target, I can pretty easily extend this to cover more targets including:

 - ubuntu 12.04 and 14.04
 - osx all the things
 - any version of ghc you probably care about
 - all the supported llvm versions
 - different gcc / clang versions
 - etc.
