### PR TITLE
Ddc build gcc pedanticness

### DIFF
--- a/make/config/flavour.mk
+++ b/make/config/flavour.mk
@@ -12,7 +12,7 @@ GCC_FLAGS	:= -std=c99 -O3 -Wundef
 # -- Development Compile (fastest compile)
 else ifeq "$(BuildFlavour)" "devel"
 GHC_FLAGS	:= -O0 $(GHC_VERSION_FLAGS) $(GHC_WARNINGS) $(GHC_LANGUAGE)
-GCC_FLAGS	:= -std=c99 -O3 -Wall -Wextra -Werror
+GCC_FLAGS	:= -std=c99 -O3 -Wall -Wextra -Werror -pedantic
 
 # -- Debug compile
 else ifeq "$(BuildFlavour)" "devel_debug"

--- a/packages/ddc-build/DDC/Build/Builder.hs
+++ b/packages/ddc-build/DDC/Build/Builder.hs
@@ -360,7 +360,7 @@ builder_X8632_Linux config host
         , buildCC
                 = \cFile oFile
                 -> doCmd "C compiler"           [(2, BuilderCanceled)]
-                [ "gcc -Werror -std=c99 -O3 -m32 -fPIC"
+                [ "gcc -Werror -Wextra -pedantic -std=c99 -O3 -m32 -fPIC"
                 , "-c", cFile
                 , "-o", oFile
                 , "-I" ++ builderConfigBaseSrcDir config </> "sea/runtime"


### PR DESCRIPTION
GCC is quite "flexible" by default, using `-Wextra` and `-pedantic` make it actually try to enforce the standard.

I think the change in 'flavour' is pretty safe, the change to Builder.hs might be contentious.

I think anytime the DDC compiler spits out non-standard C99 then that is a failure of the DDC compiler (assuming we are trying to stick to C99).

However this could mean that end-users are unable to use DDC (as the compiler refuses to compile with those flags) until we have fixed such a standard violation, this is a problem with using `-Werror` in general here.

I recommend that if you are going  to accept this change, that you first merge in the travis setup change (https://github.com/DDCSF/ddc/pull/15) to increase your confidence in this changes safety.