### PR TITLE
Adding travis badge (current build status) to Readme

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -1,5 +1,5 @@
-# The Disciplined Disciple Compiler 0.4.3
- 
+# The Disciplined Disciple Compiler 0.4.3 [![Build Status](https://travis-ci.org/DDCSF/ddc.svg?branch=master)](https://travis-ci.org/DDCSF/ddc)
+
 RELEASE NOTES 06/09/2016
 
 DDC is a research compiler used to investigate program transformation in the 


### PR DESCRIPTION
This will add a badge to your github page showing the current build status.
You can find an example of it here (see the 'build passing' badge) https://github.com/mkfifo/icarus#icarus

If you are going to accept this change please do so after you land https://github.com/DDCSF/ddc/pull/15 (and have followed the setup instructions on that PR).